### PR TITLE
supervisor script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ ltmain.sh
 missing
 stamp-h1
 watchdogd.service
+/debug/

--- a/src/conf.c
+++ b/src/conf.c
@@ -98,9 +98,9 @@ done:
 static int supervisor(uev_ctx_t *ctx, cfg_t *cfg)
 {
 	if (!cfg)
-		return supervisor_init(ctx, 0, 0);
+		return supervisor_init(ctx, 0, 0, NULL);
 
-	return supervisor_init(ctx, cfg_getbool(cfg, "enabled"), cfg_getint(cfg, "priority"));
+	return supervisor_init(ctx, cfg_getbool(cfg, "enabled"), cfg_getint(cfg, "priority"), cfg_getstr(cfg, "script"));
 }
 
 static int validate_priority(cfg_t *cfg, cfg_opt_t *opt)
@@ -142,6 +142,7 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 	cfg_opt_t supervisor_opts[] =  {
 		CFG_BOOL("enabled",  cfg_false, CFGF_NONE),
 		CFG_INT ("priority", 98, CFGF_NONE),
+		CFG_STR ("script",   NULL, CFGF_NONE),
 		CFG_END()
 	};
 	cfg_opt_t reset_cause_opts[] =  {

--- a/src/script.c
+++ b/src/script.c
@@ -108,6 +108,37 @@ int script_exec(char *exec, char *nm, int iscrit, double val, double warn, doubl
 	return 0;
 }
 
+int supervisor_script_exec(char *exec, char *label, pid_t proc_pid)
+{
+	pid_t pid;
+	char value[10];
+	char *argv[] = {
+		exec,
+		"supervisor",
+		label,
+		NULL,
+		NULL
+	};
+
+	/* Fall back to global setting checker lacks own script */
+	if (!exec)
+		return 1;
+
+	snprintf(value, sizeof(value), "%u", proc_pid);
+	argv[3] = value;
+
+	pid = fork();
+	if (!pid)
+		_exit(execv(argv[0], argv));
+	if (pid < 0) {
+		PERROR("Cannot start script %s", exec);
+		return -1;
+	}
+	LOG("Started script %s, PID %d", exec, pid);
+
+	return 0;
+}
+
 /**
  * Local Variables:
  *  indent-tabs-mode: t

--- a/src/script.h
+++ b/src/script.h
@@ -3,5 +3,6 @@
 
 int script_init (uev_ctx_t *ctx, char *script);
 int script_exec (char *exec, char *nm, int iscrit, double val, double warn, double crit);
+int supervisor_script_exec(char *exec, char *label, pid_t proc_pid);
 
 #endif /* WATCHDOGD_SCRIPT_H_ */

--- a/src/supervisor.c
+++ b/src/supervisor.c
@@ -21,6 +21,7 @@
 #include "rc.h"
 #include "wdog.h"
 #include "supervisor.h"
+#include "script.h"
 
 static struct supervisor {
 	int   id;		/* 0-255, -1: Free */
@@ -33,6 +34,7 @@ static struct supervisor {
 
 static int rtprio = 98;
 static int supervisor_enabled = 0;
+static char *exec = NULL;
 
 
 static size_t num_supervised(void)
@@ -168,7 +170,6 @@ static void timeout_cb(uev_t *w, void *arg, int events)
 {
 	struct supervisor *p = (struct supervisor *)arg;
 	wdog_reason_t reason;
-	char msg[128];
 
 	ERROR("Process %s[%d] failed to meet its deadline, rebooting ...", p->label, p->pid);
 
@@ -177,8 +178,7 @@ static void timeout_cb(uev_t *w, void *arg, int events)
 	reason.cause = WDOG_FAILED_TO_MEET_DEADLINE;
 	strlcpy(reason.label, p->label, sizeof(reason.label));
 	
-	snprintf(msg, sizeof(msg), "\"supervisor %s %d\"", reason.label, p->pid);
-	if (script_exec(NULL, msg, 1, 0.0, 0.0, 0.0))
+	if (supervisor_script_exec(exec, reason.label, p->pid))
 		wdt_reset(w->ctx, p->pid, &reason, 0);
 }
 
@@ -283,7 +283,7 @@ int supervisor_cmd(uev_ctx_t *ctx, wdog_t *req)
 	return 0;
 }
 
-int supervisor_init(uev_ctx_t *ctx, int enabled, int realtime)
+int supervisor_init(uev_ctx_t *ctx, int enabled, int realtime, char *script)
 {
 	size_t i;
 	static int already = 0;
@@ -299,6 +299,12 @@ int supervisor_init(uev_ctx_t *ctx, int enabled, int realtime)
 	if (!enabled) {
 		INFO("Process supervisor disabled.");
 		return supervisor_enable(0);
+	}
+
+	if (script) {
+		if (exec)
+			free(exec);
+		exec = strdup(script);
 	}
 
 	INFO("Starting process supervisor, waiting for client subscribe ...");

--- a/src/supervisor.c
+++ b/src/supervisor.c
@@ -168,6 +168,7 @@ static void timeout_cb(uev_t *w, void *arg, int events)
 {
 	struct supervisor *p = (struct supervisor *)arg;
 	wdog_reason_t reason;
+	char msg[128];
 
 	ERROR("Process %s[%d] failed to meet its deadline, rebooting ...", p->label, p->pid);
 
@@ -175,7 +176,10 @@ static void timeout_cb(uev_t *w, void *arg, int events)
 	reason.wid = p->id;
 	reason.cause = WDOG_FAILED_TO_MEET_DEADLINE;
 	strlcpy(reason.label, p->label, sizeof(reason.label));
-	wdt_reset(w->ctx, p->pid, &reason, 0);
+	
+	snprintf(msg, sizeof(msg), "\"supervisor %s %d\"", reason.label, p->pid);
+	if (script_exec(NULL, msg, 1, 0.0, 0.0, 0.0))
+		wdt_reset(w->ctx, p->pid, &reason, 0);
 }
 
 int supervisor_cmd(uev_ctx_t *ctx, wdog_t *req)

--- a/src/supervisor.h
+++ b/src/supervisor.h
@@ -18,7 +18,7 @@
 #ifndef WDOG_SUPERVISOR_H_
 #define WDOG_SUPERVISOR_H_
 
-int supervisor_init   (uev_ctx_t *ctx, int enabled, int realtime);
+int supervisor_init   (uev_ctx_t *ctx, int enabled, int realtime, char *script);
 int supervisor_exit   (uev_ctx_t *ctx);
 
 int supervisor_enable (int enable);

--- a/watchdogd.conf
+++ b/watchdogd.conf
@@ -30,9 +30,15 @@
 # on this, at which point watchdogd switches to SCHED_RR with the below
 # elevated realtime priority.  When the last process unsubscribes the
 # daemon reverts back to SCHED_OTHER.
+# Use "script" to run script or command when the supervised process fails
+# to meet his deadline. The script is called as:
+#
+#    script.sh supervisor PROC_LABEL PROC_PID
+#
 #supervisor {
 #    enabled  = false
 #    priority = 98
+#    script = "/path/to/supervisor-script.sh"
 #}
 
 ### Reset cause


### PR DESCRIPTION
This is a very simple draft of "supervisor script" implementation. When enabled, the global script is used.
This version is not a "final release" ready for be merged, it is only a start point for a discussion.
I propose to add a dedicated script like for the plugins.
I have some dilemmas to solve:
- Is it better to develop a dedicated "script_exec" function (supervisor_script_exec) that launchs the script with more fitted parameters, like "supervisor label pid"?
- Is it better to do not use the global script, using it only for the Checkers/Monitors?