### PR TITLE
generic script plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,9 @@ AC_ARG_ENABLE([filenr],
 AC_ARG_ENABLE([meminfo],
 	[AS_HELP_STRING([--enable-meminfo], [Enable memory leak monitor])],
 	[enable_meminfo=$enableval], [enable_meminfo=no])
+AC_ARG_ENABLE([generic],
+	[AS_HELP_STRING([--enable-generic], [Enable generic script monitor])],
+	[enable_generic=$enableval], [enable_generic=no])
 AC_ARG_ENABLE([syslog-mark],
 	[AS_HELP_STRING([--enable-syslog-mark], [Periodic syslog *MARK* by monitor plugins])],
 	[enable_syslog_mark=yes], [])
@@ -76,6 +79,10 @@ AS_IF([test "x$enable_meminfo" != "xno"], [
 	AS_IF([test "x$enable_meminfo" = "xyes"], [enable_meminfo=300])
 	AC_DEFINE_UNQUOTED(MEMINFO_PLUGIN, $enable_meminfo, [Enable memory leak monitor])])
 
+AS_IF([test "x$enable_generic" != "xno"], [
+	AS_IF([test "x$enable_generic" = "xyes"], [enable_generic=300])
+	AC_DEFINE_UNQUOTED(GENERIC_PLUGIN, $enable_generic, [Enable generic script monitor])])
+
 AS_IF([test "x$enable_syslog_mark" = "xyes"], [
 	AC_DEFINE(SYSLOG_MARK, 1, [Enable periodic syslog MARK by monitor plugins])])
 
@@ -103,6 +110,7 @@ AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemd" != "xno"])
 AM_CONDITIONAL(LOADAVG_PLUGIN, [test "x$enable_loadavg" != "xno"])
 AM_CONDITIONAL(FILENR_PLUGIN, [test "x$enable_filenr" != "xno"])
 AM_CONDITIONAL(MEMINFO_PLUGIN, [test "x$enable_meminfo" != "xno"])
+AM_CONDITIONAL(GENERIC_PLUGIN, [test "x$enable_generic" != "xno"])
 AM_CONDITIONAL(FINIT, [test "x$finit" = "xyes"])
 AM_CONDITIONAL(RCFILE, [test "x$enable_rcfile" = "xyes"])
 AM_CONDITIONAL(ENABLE_EXAMPLES, [test "$enable_examples" = yes])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,9 @@ endif
 if MEMINFO_PLUGIN
 watchdogd_SOURCES  += meminfo.c		meminfo.h
 endif
+if GENERIC_PLUGIN
+watchdogd_SOURCES  += generic.c		generic.h
+endif
 if RCFILE
 watchdogd_SOURCES  += rcfile.c		rc.h
 endif

--- a/src/conf.c
+++ b/src/conf.c
@@ -278,8 +278,6 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 #endif
 #ifdef GENERIC_PLUGIN
     generic_plugin_checker(ctx, cfg);
-#else
-#error MUDTHAVE
 #endif
 
 	return cfg_free(cfg);

--- a/src/conf.c
+++ b/src/conf.c
@@ -63,19 +63,19 @@ static int generic_plugin_checker(uev_ctx_t *ctx, cfg_t *cfg)
 	sec = cfg_getnsec(cfg, "generic", 0);
 	if (sec) {
 		int period, timeout, logmark;
-        int warn_level, crit_level;
+		int warn_level, crit_level;
 		char *script, *monitor;
-        
+
 		period  = cfg_getint(sec, "interval");
-        timeout  = cfg_getint(sec, "timeout");
+		timeout  = cfg_getint(sec, "timeout");
 		logmark = cfg_getbool(sec, "logmark");
 		warn_level = cfg_getint(sec, "warning");
 		crit_level = cfg_getint(sec, "critical");
-        monitor  = cfg_getstr(sec, "monitor-script");
+		monitor  = cfg_getstr(sec, "monitor-script");
 		script  = cfg_getstr(sec, "script");
 		return generic_init(ctx, period, timeout, monitor, logmark, warn_level, crit_level, script);
 	}
-    INFO("Generic plugin config not found, not loaded");
+	INFO("Generic plugin config section not found, not loaded");
 	return 0;
 }
 #endif

--- a/src/conf.c
+++ b/src/conf.c
@@ -26,7 +26,7 @@
 #include "loadavg.h"
 #include "meminfo.h"
 #include "supervisor.h"
-
+#include "generic.h"
 
 #if defined(LOADAVG_PLUGIN) || defined(MEMINFO_PLUGIN) || defined(FILENR_PLUGIN)
 static int checker(uev_ctx_t *ctx, cfg_t *cfg, const char *sect,
@@ -52,6 +52,31 @@ static int checker(uev_ctx_t *ctx, cfg_t *cfg, const char *sect,
 	}
 
 	return rc;
+}
+#endif
+
+#if defined(GENERIC_PLUGIN)
+static int generic_plugin_checker(uev_ctx_t *ctx, cfg_t *cfg)
+{
+	cfg_t *sec;
+
+	sec = cfg_getnsec(cfg, "generic", 0);
+	if (sec) {
+		int period, timeout, logmark;
+        int warn_level, crit_level;
+		char *script, *monitor;
+        
+		period  = cfg_getint(sec, "interval");
+        timeout  = cfg_getint(sec, "timeout");
+		logmark = cfg_getbool(sec, "logmark");
+		warn_level = cfg_getint(sec, "warning");
+		crit_level = cfg_getint(sec, "critical");
+        monitor  = cfg_getstr(sec, "monitor-script");
+		script  = cfg_getstr(sec, "script");
+		return generic_init(ctx, period, timeout, monitor, logmark, warn_level, crit_level, script);
+	}
+    INFO("Generic plugin config not found, not loaded");
+	return 0;
 }
 #endif
 
@@ -165,6 +190,17 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 		CFG_STR  ("script",   NULL, CFGF_NONE),
 		CFG_END()
 	};
+    cfg_opt_t generic_plugin_opts[] = {
+		CFG_INT  ("interval", 300, CFGF_NONE),
+        CFG_INT  ("timeout", 300, CFGF_NONE),
+		CFG_BOOL ("logmark",  cfg_false, CFGF_NONE),
+		CFG_INT  ("warning",  1, CFGF_NONE),
+		CFG_INT  ("critical",  2, CFGF_NONE),
+        CFG_STR  ("monitor-script",   NULL, CFGF_NONE),
+		CFG_STR  ("script",   NULL, CFGF_NONE),
+		CFG_END()
+	};
+    
 	cfg_opt_t opts[] = {
 		CFG_INT ("interval",    WDT_KICK_DEFAULT, CFGF_NONE),
 		CFG_INT ("timeout",     WDT_TIMEOUT_DEFAULT, CFGF_NONE),
@@ -175,6 +211,7 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 		CFG_SEC ("filenr",      checker_opts, CFGF_NONE),
 		CFG_SEC ("loadavg",     checker_opts, CFGF_NONE),
 		CFG_SEC ("meminfo",     checker_opts, CFGF_NONE),
+        CFG_SEC ("generic",     generic_plugin_opts, CFGF_NONE),
 		CFG_END()
 	};
 	cfg_t *cfg;
@@ -238,6 +275,11 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 #endif
 #ifdef MEMINFO_PLUGIN
 	checker(ctx, cfg, "meminfo", meminfo_init);
+#endif
+#ifdef GENERIC_PLUGIN
+    generic_plugin_checker(ctx, cfg);
+#else
+#error MUDTHAVE
 #endif
 
 	return cfg_free(cfg);

--- a/src/generic.c
+++ b/src/generic.c
@@ -18,7 +18,6 @@
 
 #include <sys/wait.h>
 #include <unistd.h>
-#include <signal.h>
 
 #include "wdt.h"
 #include "script.h"
@@ -46,7 +45,7 @@ static void wait_for_generic_script(uev_t *w, void *arg, int events)
 	DEBUG("Monitor Script (PID %d) verifying if still running, events: %d", script_args->pid, events);
 	status = get_exit_code_for_pid(script_args->pid);
 	if (status >= 0) {
-		uev_signal_stop(&script_args->monitor_script_watcher);
+		uev_timer_stop(&script_args->monitor_script_watcher);
 		script_args->is_running = 0;
 		
 		if (status >= script_args->critical) {

--- a/src/generic.c
+++ b/src/generic.c
@@ -24,16 +24,16 @@
 #include "script.h"
 
 typedef struct generic_script {
-    uev_t watcher;
-    int is_running;
-    int monitor_run_time;
-    int max_monitor_run_time;
-    pid_t pid;
-    int warning;
-    int critical;
-    uev_t monitor_script_watcher;
-    char *monitor_script;
-    char *exec;
+	uev_t watcher;
+	int is_running;
+	int monitor_run_time;
+	int max_monitor_run_time;
+	pid_t pid;
+	int warning;
+	int critical;
+	uev_t monitor_script_watcher;
+	char *monitor_script;
+	char *exec;
 } generic_script_t;
 
 static generic_script_t* single_monitor_script = NULL;
@@ -41,110 +41,104 @@ static generic_script_t* single_monitor_script = NULL;
 static void wait_for_generic_script(uev_t *w, void *arg, int events)
 {
 	int status;
-    generic_script_t* script_args;
-    script_args = (generic_script_t*)arg;
-    DEBUG("Monitor Script (PID %d) verifying if still running, events: %d", script_args->pid, events);
-    status = get_exit_code_for_pid(script_args->pid);
+	generic_script_t* script_args;
+	script_args = (generic_script_t*)arg;
+	DEBUG("Monitor Script (PID %d) verifying if still running, events: %d", script_args->pid, events);
+	status = get_exit_code_for_pid(script_args->pid);
 	if (status >= 0) {
-        uev_signal_stop(&script_args->monitor_script_watcher);
-        script_args->is_running = 0;
-
-        if (status >= script_args->critical) 
-        {
-            ERROR("Monitor Script (PID %d) returned exit status above critical treshold: %d, rebooting system ...", script_args->pid, status);
-            if (checker_exec(script_args->exec, "generic", 1, status, script_args->warning, script_args->critical))
-                wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
-        } 
-        else if(status >= script_args->warning)
-        {
-            WARN("Monitor Script (PID %d) returned exit status above warning treshold: %d", script_args->pid, status);
-            checker_exec(script_args->exec, "generic", 0, status, script_args->warning, script_args->critical);
-        }
-        else 
-        {
-            INFO("Monitor Script (PID %d) ran OK", script_args->pid);
-        }
-    }
-    else
-    {
-        script_args->monitor_run_time += 1000;
-        
-        if(script_args->monitor_run_time >= script_args->max_monitor_run_time) 
-        {
-            ERROR("Monitor Script (PID %d) still running after %d s", script_args->pid, script_args->max_monitor_run_time);
-        }
-    }
+		uev_signal_stop(&script_args->monitor_script_watcher);
+		script_args->is_running = 0;
+		
+		if (status >= script_args->critical) {
+			ERROR("Monitor Script (PID %d) returned exit status above critical treshold: %d, rebooting system ...", script_args->pid, status);
+			if (checker_exec(script_args->exec, "generic", 1, status, script_args->warning, script_args->critical))
+				wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
+		} else if(status >= script_args->warning) {
+			WARN("Monitor Script (PID %d) returned exit status above warning treshold: %d", script_args->pid, status);
+			checker_exec(script_args->exec, "generic", 0, status, script_args->warning, script_args->critical);
+		} else {
+			INFO("Monitor Script (PID %d) ran OK", script_args->pid);
+		}
+	} else {
+		script_args->monitor_run_time += 1000;
+		
+		if(script_args->monitor_run_time >= script_args->max_monitor_run_time) {
+			ERROR("Monitor Script (PID %d) still running after %d s", script_args->pid, script_args->max_monitor_run_time);
+			if (checker_exec(script_args->exec, "generic", 1, 255, script_args->warning, script_args->critical))
+				wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
+		}
+	}
 }
 
 static int run_generic_script(uev_t *w, generic_script_t* script_args) 
 {   
-    script_args->pid = generic_exec(script_args->monitor_script, script_args->warning, script_args->critical);
-    if (script_args->pid > 0) 
-    {
-        INFO("Started generic monitor script %s with PID %d", script_args->monitor_script, script_args->pid);
-        script_args->is_running = 1;   
-        uev_timer_stop(&script_args->monitor_script_watcher);
-        script_args->monitor_run_time = 0;
-        uev_timer_init(w->ctx, &script_args->monitor_script_watcher, wait_for_generic_script, script_args, 1000, 1000);    
-    }
-    else
-    {
-        ERROR("Could not start generic monitor script %s", script_args->monitor_script);
-        return -1;
-    }
-    
-    return script_args->pid;
+	script_args->pid = generic_exec(script_args->monitor_script, script_args->warning, script_args->critical);
+	if (script_args->pid > 0) 
+	{
+		INFO("Started generic monitor script %s with PID %d", script_args->monitor_script, script_args->pid);
+		script_args->is_running = 1;   
+		uev_timer_stop(&script_args->monitor_script_watcher);
+		script_args->monitor_run_time = 0;
+		uev_timer_init(w->ctx, &script_args->monitor_script_watcher, wait_for_generic_script, script_args, 1000, 1000);    
+	}
+	else
+	{
+		ERROR("Could not start generic monitor script %s", script_args->monitor_script);
+		return -1;
+	}
+	
+	return script_args->pid;
 }
 
 static void cb(uev_t *w, void *arg, int events)
 {
-    generic_script_t* script_args;
-    script_args = (generic_script_t*)arg;    
-    if (!script_args) {
-        ERROR("Oops, no args?");
+	generic_script_t* script_args;
+	script_args = (generic_script_t*)arg;    
+	if (!script_args) {
+		ERROR("Oops, no args?");
 		return;
-    }
-    
-    if(!script_args->is_running) {
-        INFO("Starting the generic monitor script");
-        
-        if(run_generic_script(w, script_args) <= 0)
-        {
-            if (script_args->critical > 0) 
-            {
-                ERROR("Could not start the monitor script %s, rebooting system ...", script_args->monitor_script);
-                if (checker_exec(script_args->exec, "generic", 1, 100, script_args->warning, script_args->critical))
-                    wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
-            }
-            else 
-            {
-                WARN("Could not start the monitor script %s, but is not critical", script_args->monitor_script);
-            }
-            return;
-        }
-    }
-    else 
-    {
-        ERROR("Timeout reached and the script %s is still running, rebooting system ...", script_args->monitor_script);
-        if (checker_exec(script_args->exec, "generic", 1, 100, script_args->warning, script_args->critical))
-            wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
-        return;
-    }
+	}
+	
+	if(!script_args->is_running) {
+		INFO("Starting the generic monitor script");
+		
+		if(run_generic_script(w, script_args) <= 0)
+		{
+			if (script_args->critical > 0) 
+			{
+				ERROR("Could not start the monitor script %s, rebooting system ...", script_args->monitor_script);
+				if (checker_exec(script_args->exec, "generic", 1, 100, script_args->warning, script_args->critical))
+					wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
+			}
+			else 
+			{
+				WARN("Could not start the monitor script %s, but is not critical", script_args->monitor_script);
+			}
+			return;
+		}
+	}
+	else 
+	{
+		ERROR("Timeout reached and the script %s is still running, rebooting system ...", script_args->monitor_script);
+		if (checker_exec(script_args->exec, "generic", 1, 100, script_args->warning, script_args->critical))
+			wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
+		return;
+	}
 }
 
 static void stop_and_cleanup(generic_script_t* script) 
 {
-    if(script) {
-        uev_timer_stop(&script->monitor_script_watcher);
-        uev_timer_stop(&script->watcher);
-        if(script->exec) {
-            free(script->exec);
-        }
-        if(script->monitor_script) {
-            free(script->monitor_script);
-        }
-        free(script);
-    }
+	if(script) {
+		uev_timer_stop(&script->monitor_script_watcher);
+		uev_timer_stop(&script->watcher);
+		if(script->exec) {
+			free(script->exec);
+		}
+		if(script->monitor_script) {
+			free(script->monitor_script);
+		}
+		free(script);
+	}
 }
 
 /*
@@ -155,40 +149,40 @@ int generic_init(uev_ctx_t *ctx, int T, int timeout, char *monitor, int mark, in
 {
 	if (!T) {
 		INFO("Generic script monitor disabled.");
-        stop_and_cleanup(single_monitor_script);
-        single_monitor_script = NULL;
-        return 0;
+		stop_and_cleanup(single_monitor_script);
+		single_monitor_script = NULL;
+		return 0;
 	}
-
-    if (!monitor) {
+	
+	if (!monitor) {
 		ERROR("Generic script monitor not started, please provide script-monitor.");
-        stop_and_cleanup(single_monitor_script);
-        single_monitor_script = NULL;
-        return 0;
+		stop_and_cleanup(single_monitor_script);
+		single_monitor_script = NULL;
+		return 0;
 	}
-    
+	
 	INFO("Generic script monitor, period %d sec, max timeout: %d, monitor script: %s, warning level: %d, critical level: %d", T, timeout, monitor, warn, crit);
-
-    stop_and_cleanup(single_monitor_script);
-        
-    single_monitor_script = (generic_script_t*) malloc(sizeof (generic_script_t));
-    if(single_monitor_script) {
-        single_monitor_script->is_running = 0;
-        single_monitor_script->pid = -1;
-        single_monitor_script->warning = warn;
-        single_monitor_script->critical = crit;  
-        single_monitor_script->max_monitor_run_time = timeout;
-        single_monitor_script->monitor_script = strdup(monitor);
-        single_monitor_script->exec = NULL;
-        if (script) 
-        {
-            single_monitor_script->exec = strdup(script);            
-        }
-        INFO("Start monitor timer");
-        
-        return uev_timer_init(ctx, &single_monitor_script->watcher, cb, single_monitor_script, T * 1000, T * 1000);
-    }
-    return 0;
+	
+	stop_and_cleanup(single_monitor_script);
+	
+	single_monitor_script = (generic_script_t*) malloc(sizeof (generic_script_t));
+	if(single_monitor_script) {
+		single_monitor_script->is_running = 0;
+		single_monitor_script->pid = -1;
+		single_monitor_script->warning = warn;
+		single_monitor_script->critical = crit;  
+		single_monitor_script->max_monitor_run_time = timeout;
+		single_monitor_script->monitor_script = strdup(monitor);
+		single_monitor_script->exec = NULL;
+		if (script) 
+		{
+			single_monitor_script->exec = strdup(script);            
+		}
+		INFO("Start monitor timer");
+		
+		return uev_timer_init(ctx, &single_monitor_script->watcher, cb, single_monitor_script, T * 1000, T * 1000);
+	}
+	return 0;
 }
 
 /**

--- a/src/generic.c
+++ b/src/generic.c
@@ -166,6 +166,7 @@ int generic_init(uev_ctx_t *ctx, int T, int timeout, char *monitor, int mark, in
 	
 	single_monitor_script = (generic_script_t*) malloc(sizeof (generic_script_t));
 	if(single_monitor_script) {
+        memset(single_monitor_script, 0, sizeof(generic_script_t));
 		single_monitor_script->is_running = 0;
 		single_monitor_script->pid = -1;
 		single_monitor_script->warning = warn;

--- a/src/generic.c
+++ b/src/generic.c
@@ -1,0 +1,169 @@
+/* Generic script monitor
+ *
+ * Copyright (C) 2015       Christian Lockley <clockley1@gmail.com>
+ * Copyright (C) 2015-2018  Joachim Nilsson <troglobit@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "wdt.h"
+#include "script.h"
+
+static uev_t watcher;
+
+typedef struct generic_script {  
+    int is_running;
+    pid_t pid;
+    int warning;
+    int critical;
+    char *monitor_script;
+    char *exec;
+} generic_script_t;
+
+
+static void wait_for_generic_script(uev_t *w, void *arg, int events)
+{
+	int status;
+    pid_t pid = 1;
+    generic_script_t* script_args;
+    script_args = (generic_script_t*) arg;
+
+    INFO("Monitor Script (PID %d): Got SIGCHLD so checking exit code, events: %d", script_args->pid, events);
+	while ((pid = waitpid(script_args->pid, &status, WNOHANG)) > 0) {
+
+		status = WEXITSTATUS(status);
+        if (status >= script_args->critical) 
+        {
+            ERROR("Monitor Script (PID %d) returned exit status above critical treshold: %d, rebooting system ...", pid, status);
+            if (checker_exec(script_args->exec, "generic", 1, status, script_args->warning, script_args->critical))
+                wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
+        } 
+        else if(status >= script_args->warning)
+        {
+			WARN("Monitor Script (PID %d) returned exit status above warning treshold: %d", pid, status);
+            checker_exec(script_args->exec, "generic", 0, status, script_args->warning, script_args->critical);
+        }
+        else 
+        {
+            INFO("Monitor script ran OK");
+        }
+        break;
+	}
+    INFO("Sigchild callback done");
+}
+
+static int run_generic_script(uev_t *w, generic_script_t* script_args) 
+{
+    pid_t pid;    
+    pid = fork();
+    if (!pid) {
+        char value[5];
+        char *argv[] = {
+            script_args->monitor_script,
+            NULL,
+            NULL,
+        };
+        snprintf(value, sizeof(value), "%d", script_args->warning);
+        argv[1] = value;
+        snprintf(value, sizeof(value), "%d", script_args->critical);
+        argv[2] = value;
+        _exit(execv(argv[0], argv));
+    }
+    if (pid < 0) {
+        ERROR("Cannot start script %s", script_args->monitor_script);
+        return -1;
+    }
+    INFO("Started generic monitor script %s with PID %d", script_args->monitor_script, pid);
+    uev_signal_init(w->ctx, &watcher, wait_for_generic_script, script_args, SIGCHLD);
+    return pid;
+}
+
+static void cb(uev_t *w, void *arg, int events)
+{
+    generic_script_t* script_args;
+    script_args = (generic_script_t*) arg;
+    if (!script_args) {
+        ERROR("Oops, no args?");
+		return;
+    }
+    
+    if(!script_args->is_running) {
+        INFO("Starting the generic monitor script");
+        
+        script_args->pid = run_generic_script(w, script_args);
+        if(script_args->pid > 0) {
+            script_args->is_running = 1;
+        }
+    }
+    else 
+    {
+        ERROR("Timeout reached and the script %s is still running, rebooting system ...", script_args->monitor_script);
+        if (checker_exec(script_args->exec, "generic", 1, 100, script_args->warning, script_args->critical))
+            wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
+        return;
+    }
+}
+
+/*
+ * Every T seconds we run the given script
+ * If it returns nonzero or runs for more than timeout we are critical
+ */
+int generic_init(uev_ctx_t *ctx, int T, int timeout, char *monitor, int mark, int warn, int crit, char *script)
+{
+	if (!T) {
+		INFO("Generic script monitor disabled.");
+		return uev_timer_stop(&watcher);
+	}
+
+    if (!monitor) {
+		ERROR("Generic script monitor not started, please provide script-monitor.");
+		return uev_timer_stop(&watcher);
+	}
+    
+	INFO("Generic script monitor, period %d sec, max timeout: %d, monitor script: %s, warning level: %d, critical level: %d", T, timeout, monitor, warn, crit);
+
+	uev_timer_stop(&watcher);
+    //todo: get any old args and free them + free their monitor_script and exec fields
+    
+    generic_script_t* script_args;
+    script_args = (generic_script_t*) malloc(sizeof (generic_script_t));
+    INFO("OK 1");
+    if(script_args) {
+        script_args->is_running = 0;
+        script_args->pid = -1;
+        script_args->warning = warn;
+        script_args->critical = crit;    
+        INFO("OK 2");
+        script_args->monitor_script = strdup(monitor);
+        INFO("OK 3");
+        script_args->exec = NULL;
+        if (script) 
+        {
+            script_args->exec = strdup(script);            
+        }
+        
+        INFO("OK 4");
+    }
+    INFO("OK 5");
+	return uev_timer_init(ctx, &watcher, cb, script_args, timeout * 1000, T * 1000);
+}
+
+/**
+ * Local Variables:
+ *  c-file-style: "linux"
+ *  indent-tabs-mode: t
+ * End:
+ */

--- a/src/generic.c
+++ b/src/generic.c
@@ -25,8 +25,9 @@
 
 typedef struct generic_script {
     uev_t watcher;
-    int is_init;
     int is_running;
+    int monitor_run_time;
+    int max_monitor_run_time;
     pid_t pid;
     int warning;
     int critical;
@@ -40,78 +41,59 @@ static generic_script_t* single_monitor_script = NULL;
 static void wait_for_generic_script(uev_t *w, void *arg, int events)
 {
 	int status;
-    pid_t pid = 1;
     generic_script_t* script_args;
     script_args = (generic_script_t*)arg;
-    INFO("Monitor Script (PID %d): verifying if still running, events: %d", script_args->pid, events);
-	if ((pid = waitpid(script_args->pid, &status, WNOHANG)) > 0) {
+    DEBUG("Monitor Script (PID %d) verifying if still running, events: %d", script_args->pid, events);
+    status = get_exit_code_for_pid(script_args->pid);
+	if (status >= 0) {
+        uev_signal_stop(&script_args->monitor_script_watcher);
+        script_args->is_running = 0;
 
-        if(pid == script_args->pid) {
-            uev_timer_stop(&script_args->monitor_script_watcher);
-            script_args->is_running = 0;
-            
-            status = WEXITSTATUS(status);
-            if (status >= script_args->critical) 
-            {
-                ERROR("Monitor Script (PID %d) returned exit status above critical treshold: %d, rebooting system ...", pid, status);
-                if (checker_exec(script_args->exec, "generic", 1, status, script_args->warning, script_args->critical))
-                    wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
-            } 
-            else if(status >= script_args->warning)
-            {
-                WARN("Monitor Script (PID %d) returned exit status above warning treshold: %d", pid, status);
-                checker_exec(script_args->exec, "generic", 0, status, script_args->warning, script_args->critical);
-            }
-            else 
-            {
-                INFO("Monitor script ran OK");            
-            }
-            
-        }
-        else
+        if (status >= script_args->critical) 
         {
-            INFO("Monitor script waitpid %d and script is %d", pid, script_args->pid);    
+            ERROR("Monitor Script (PID %d) returned exit status above critical treshold: %d, rebooting system ...", script_args->pid, status);
+            if (checker_exec(script_args->exec, "generic", 1, status, script_args->warning, script_args->critical))
+                wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);
+        } 
+        else if(status >= script_args->warning)
+        {
+            WARN("Monitor Script (PID %d) returned exit status above warning treshold: %d", script_args->pid, status);
+            checker_exec(script_args->exec, "generic", 0, status, script_args->warning, script_args->critical);
         }
-	}
+        else 
+        {
+            INFO("Monitor Script (PID %d) ran OK", script_args->pid);
+        }
+    }
     else
-    {        
-        INFO("Monitor script still running: waitpid: %d  errno: %d", pid, errno);
+    {
+        script_args->monitor_run_time += 1000;
+        
+        if(script_args->monitor_run_time >= script_args->max_monitor_run_time) 
+        {
+            ERROR("Monitor Script (PID %d) still running after %d s", script_args->pid, script_args->max_monitor_run_time);
+        }
     }
 }
 
 static int run_generic_script(uev_t *w, generic_script_t* script_args) 
-{
-    pid_t pid;    
-    pid = fork();
-    if (!pid) {
-        char value[5];
-        char *argv[] = {
-            script_args->monitor_script,
-            NULL,
-            NULL,
-            0
-        };
-        snprintf(value, sizeof(value), "%d", script_args->warning);
-        argv[1] = value;
-        snprintf(value, sizeof(value), "%d", script_args->critical);
-        argv[2] = value;
-        sigset_t sigs;
-        sigfillset(&sigs);
-        sigprocmask(SIG_UNBLOCK, &sigs, 0);
-        _exit(execv(argv[0], argv));
+{   
+    script_args->pid = generic_exec(script_args->monitor_script, script_args->warning, script_args->critical);
+    if (script_args->pid > 0) 
+    {
+        INFO("Started generic monitor script %s with PID %d", script_args->monitor_script, script_args->pid);
+        script_args->is_running = 1;   
+        uev_timer_stop(&script_args->monitor_script_watcher);
+        script_args->monitor_run_time = 0;
+        uev_timer_init(w->ctx, &script_args->monitor_script_watcher, wait_for_generic_script, script_args, 1000, 1000);    
     }
-    if (pid < 0) {
-        ERROR("Cannot start script %s", script_args->monitor_script);
+    else
+    {
+        ERROR("Could not start generic monitor script %s", script_args->monitor_script);
         return -1;
     }
-    INFO("Started generic monitor script %s with PID %d", script_args->monitor_script, pid);
-    script_args->pid = pid;
-    script_args->is_running = 1;
     
-    uev_timer_stop(&script_args->monitor_script_watcher);
-    uev_timer_init(w->ctx, &script_args->monitor_script_watcher, wait_for_generic_script, script_args, 1000, 1000);    
-        
-    return pid;
+    return script_args->pid;
 }
 
 static void cb(uev_t *w, void *arg, int events)
@@ -192,10 +174,10 @@ int generic_init(uev_ctx_t *ctx, int T, int timeout, char *monitor, int mark, in
     single_monitor_script = (generic_script_t*) malloc(sizeof (generic_script_t));
     if(single_monitor_script) {
         single_monitor_script->is_running = 0;
-        single_monitor_script->is_init = 0;
         single_monitor_script->pid = -1;
         single_monitor_script->warning = warn;
-        single_monitor_script->critical = crit;    
+        single_monitor_script->critical = crit;  
+        single_monitor_script->max_monitor_run_time = timeout;
         single_monitor_script->monitor_script = strdup(monitor);
         single_monitor_script->exec = NULL;
         if (script) 

--- a/src/generic.h
+++ b/src/generic.h
@@ -1,0 +1,31 @@
+/* Generic script monitor
+ *
+ * Copyright (C) 2015       Christian Lockley <clockley1@gmail.com>
+ * Copyright (C) 2015-2018  Joachim Nilsson <troglobit@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef WDOG_GENERIC_H_
+#define WDOG_GENERIC_H_
+
+int generic_init(uev_ctx_t* ctx, int T, int timeout, char* monitor, int mark, int warn, int crit, char* script);
+
+#endif /* WDOG_GENERIC_H_ */
+
+/**
+ * Local Variables:
+ *  c-file-style: "linux"
+ *  indent-tabs-mode: t
+ * End:
+ */

--- a/src/script.h
+++ b/src/script.h
@@ -1,8 +1,10 @@
 #ifndef WATCHDOGD_SCRIPT_H_
 #define WATCHDOGD_SCRIPT_H_
 
-int script_init (uev_ctx_t *ctx, char *script);
-int checker_exec (char *exec, char *nm, int iscrit, double val, double warn, double crit);
-int supervisor_exec(char *exec, int c, int p, char *label);
+int script_init(uev_ctx_t* ctx, char* script);
+int checker_exec(char* exec, char* nm, int iscrit, double val, double warn, double crit);
+int supervisor_exec(char* exec, int c, int p, char* label);
+int generic_exec(char* exec, int warn, int crit);
+int get_exit_code_for_pid(pid_t pid);
 
 #endif /* WATCHDOGD_SCRIPT_H_ */

--- a/watchdogd.conf
+++ b/watchdogd.conf
@@ -97,3 +97,17 @@
 #    critical = 0.95
 #    script = "/path/to/meminfo-script.sh"
 #}
+
+# Monitors by executing a monitor-script every "interval" seconds
+# The monitor-script must run within "timeout" seconds. When the
+# exit code of the monitor script is above the critical number a
+# reboot is scheduled.
+#generic {
+#    interval = 300
+#    timeout = 60
+#    logmark  = false
+#    warning  = 1
+#    critical = 10
+#    monitor-script = "/path/to/monitor-script.sh"
+#    script = "/path/to/generic-script.sh"
+#}

--- a/watchdogd.conf
+++ b/watchdogd.conf
@@ -70,7 +70,7 @@
 #
 #script = "/path/to/script.sh"
 
-# Monitors file desriptor leaks based on /proc/sys/fs/file-nr
+# Monitors file descriptor leaks based on /proc/sys/fs/file-nr
 #filenr {
 #    interval = 300
 #    logmark  = false


### PR DESCRIPTION
PR opened to get some feedback and help. First time I use that libuev library, and long time ago I programmed C instead of C++ haha, so I need some guidance. 

It would already work, but when the child process is done, I get indeed the callback, then I read the returned status, and check the warning and critical error levels. But...There is an infinite loop where I keep getting SIGCHLD. Help is needed :)

This is what I get. Note: My main App is subscribed and kicking the supervisor just before I disabled the watchdog, so that is why these invalid credentials lines are there.
```
$ watchdogctl disable
$ pkill watchdogd
<<<<<<<< now I upload my newly compiled version using scp
$ watchdogd -n -l debug
watchdogd[1369]: Starting process supervisor, waiting for client subscribe ...
watchdogd[1369]: Setting SCHED_OTHER prio 0
watchdogd[1369]: Generic script monitor, period 5 sec, max timeout: 2, monitor script: /root/check-wd.sh, warning level: 1, critical level: 10
watchdogd[1369]: OK 1
watchdogd[1369]: OK 2
watchdogd[1369]: OK 3
watchdogd[1369]: OK 4
watchdogd[1369]: OK 5
watchdogd[1369]: watchdogd v3.1 starting ...
watchdogd[1369]: /dev/watchdog: Broadcom BCM2835 Watchdog timer, capabilities 0x8180
watchdogd[1369]: WDT does not support PWR fail condition, treating as card reset.
watchdogd[1369]: Setting watchdog timeout to 10 sec.
watchdogd[1369]: Watchdog timeout is set to 10 sec.
watchdogd[1369]: Watchdog kick interval set to 4 sec.
watchdogd[1369]: App[1300] tried to kick with invalid credentials: Identifier removed
watchdogd[1369]: Starting the generic monitor script
watchdogd[1369]: Started generic monitor script /root/check-wd.sh with PID 1370
watchdogd[1369]: Monitor Script (PID 1370): Got SIGCHLD so checking exit code, events: 1
watchdogd[1369]: Monitor script ran OK
watchdogd[1369]: Sigchild callback done
watchdogd[1369]: App[1300] tried to kick with invalid credentials: Identifier removed
watchdogd[1369]: Kicking watchdog.
watchdogd[1369]: Kicking WDT.
watchdogd[1369]: App[1300] tried to kick with invalid credentials: Identifier removed
watchdogd[1369]: Monitor Script (PID 1370): Got SIGCHLD so checking exit code, events: 1
watchdogd[1369]: Sigchild callback done
watchdogd[1369]: Monitor Script (PID 1370): Got SIGCHLD so checking exit code, events: 1
watchdogd[1369]: Sigchild callback done
watchdogd[1369]: Monitor Script (PID 1370): Got SIGCHLD so checking exit code, events: 1
watchdogd[1369]: Sigchild callback done
watchdogd[1369]: Monitor Script (PID 1370): Got SIGCHLD so checking exit code, events: 1
watchdogd[1369]: Sigchild callback done
watchdogd[1369]: Monitor Script (PID 1370): Got SIGCHLD so checking exit code, events: 1
watchdogd[1369]: Sigchild callback done
......
......etc
```

Best regards,
Tom,