### PR TITLE
Reset cause vs reset reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ resetting the system.  In its more advanced guise it monitors critical
 system resources, supervises the heartbeat of processes, records
 deadline transgressions, and initiates a controlled reset if needed.
 
-When a system comes back up after a reset, `watchdogd` determines the
-reset cause and records it in a file for later analysis by an operator
-or network management system (NMS).  This information in turn can be
-used to put the system in an operational safe state, or non-operational
-safe state.
+When a system starts up, `watchdogd` determines the reset cause by
+querying the kernel.  In case of system reset, and not power loss, the
+reset reason is available already in a file for later analysis by an
+operator or network management system (NMS).  This information can in
+turn can be used to put the system in an operational safe state, or
+non-operational safe state.
 
 
 ### What is a watchdog timer?
@@ -57,8 +58,8 @@ module which in many cases can be good enough.
 The idea of a watchdog daemon in userspace is to run in the background
 of your system.  When there is no more CPU time for the watchdog daemon
 to run it will fail to "kick" the WDT.  This will in turn cause the WDT
-to reboot the system.  When it does `watchdogd` have already saved the
-reset cause for your post mortem.
+to reboot the system.  When it does `watchdogd` has already saved the
+reset reason for your post mortem.
 
 As a background process, `watchdogd` can of course also be used to
 monitor other aspects of the system ...
@@ -200,18 +201,19 @@ internal deadlines be supervised.
 
 When a process fails to meet its deadlines, or a monitor plugin reaches
 critical level, `watchdogd` initiates a controlled reset.  To see the
-reset cause after reboot, the following section must be enabled in the
+reset reason after reboot, the following section must be enabled in the
 `/etc/watchdogd.conf` file:
 
 ```
-reset-cause {
+reset-reason {
     enabled = true
-#   file    = /var/lib/watchdogd.state
+#   file    = /var/lib/watchdogd.state  # default
 }
 ```
 
 The `file` setting is optional, the default is usually sufficient, but
-make sure the destination directory is writable if you change it.
+make sure the destination directory is writable if you change it.  You
+can either inspect the file, or use the `watchdogctl` tool.
 
 
 libwdog API

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ aspects of the system, such as:
 - Memory leaks
 - File descriptor leaks
 - Process live locks
-- Reset counter, for snmpEngineBoots (RFC 2574)
+- Reset counter, warm boots since last power failure
 
 To top things off there is support for periodically calling a generic
 script where operators can do housekeeping checks.  For details on how

--- a/configure.ac
+++ b/configure.ac
@@ -57,8 +57,8 @@ AC_ARG_ENABLE(test-mode,
         AS_HELP_STRING([--disable-test-mode], [Disable test mode]))
 AC_ARG_ENABLE(builtin-tests,
         AS_HELP_STRING([--disable-builtin-tests], [Disable process supervisor built-in tests]))
-AC_ARG_ENABLE(rcfile,
-        AS_HELP_STRING([--disable-rcfile], [Disable file store reset cause backend]))
+AC_ARG_ENABLE(rrfile,
+        AS_HELP_STRING([--disable-rrfile], [Disable reset reason file store backend]))
 
 AC_ARG_WITH([systemd],
 	[AS_HELP_STRING([--with-systemd=DIR], [Directory for systemd service files, default: auto])],,
@@ -92,8 +92,8 @@ AS_IF([test "x$enable_test_mode" != "xno"], enable_test_mode="yes",[
 AS_IF([test "x$enable_builtin_tests" != "xno"], enable_builtin_tests="yes",[
 	AC_DEFINE(SUPERVISOR_TESTS_DISABLED,  1, [Disable process supervisor tests in watchdogctl])])
 
-AS_IF([test "x$enable_rcfile" != "xno"], enable_rcfile="yes",[
-	AC_DEFINE(RCFILE_DISABLED,  1, [Disable reset cause file store backend])])
+AS_IF([test "x$enable_rrfile" != "xno"], enable_rrfile="yes",[
+	AC_DEFINE(RRFILE_DISABLED,  1, [Disable reset reason file store backend])])
 
 # Check where to install the systemd .service file
 AS_IF([test "x$with_systemd" = "xyes" -o "x$with_systemd" = "xauto"], [
@@ -112,7 +112,7 @@ AM_CONDITIONAL(FILENR_PLUGIN, [test "x$enable_filenr" != "xno"])
 AM_CONDITIONAL(MEMINFO_PLUGIN, [test "x$enable_meminfo" != "xno"])
 AM_CONDITIONAL(GENERIC_PLUGIN, [test "x$enable_generic" != "xno"])
 AM_CONDITIONAL(FINIT, [test "x$finit" = "xyes"])
-AM_CONDITIONAL(RCFILE, [test "x$enable_rcfile" = "xyes"])
+AM_CONDITIONAL(RRFILE, [test "x$enable_rrfile" = "xyes"])
 AM_CONDITIONAL(ENABLE_EXAMPLES, [test "$enable_examples" = yes])
 
 # Expand $sbindir early, into $SBINDIR, for systemd unit file
@@ -141,25 +141,25 @@ cat <<EOF
 
 ------------------ Summary ------------------
  $PACKAGE_NAME version $PACKAGE_VERSION
-  Prefix..........: $prefix
-  Sysconfdir......: $SYSCONFDIR
-  Runstatedir.....: $RUNSTATEDIR
-  C Compiler......: $CC $CFLAGS $CPPFLAGS $LDFLAGS $LIBS
+  Prefix.............: $prefix
+  Sysconfdir.........: $SYSCONFDIR
+  Runstatedir........: $RUNSTATEDIR
+  C Compiler.........: $CC $CFLAGS $CPPFLAGS $LDFLAGS $LIBS
 
  Optional features:
-  compat mode.....: $enable_compat
-  client examples.: $enable_examples
-  test mode.......: $enable_test_mode
-  built-in tests..: $enable_builtin_tests
-  reset cause file: $enable_rcfile
-  systemd.........: $with_systemd
+  compat mode........: $enable_compat
+  client examples....: $enable_examples
+  test mode..........: $enable_test_mode
+  built-in tests.....: $enable_builtin_tests
+  reset reason file..: $enable_rrfile
+  systemd............: $with_systemd
 
  Plugins:
-  loadavg.........: $enable_loadavg
-  filenr..........: $enable_filenr
-  meminfo.........: $enable_meminfo
-  generic script..: $enable_generic
-  syslog mark.....: $enable_syslog_mark
+  loadavg............: $enable_loadavg
+  filenr.............: $enable_filenr
+  meminfo............: $enable_meminfo
+  generic script.....: $enable_generic
+  syslog mark........: $enable_syslog_mark
 
 ------------- Compiler version --------------
 $($CC --version || true)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -51,10 +51,8 @@ periodically and responds to client requests.
 
 For each reboot `watchdogd` maintains a reset counter, along with the
 data collected in the (state) file.  This reset counter is incremeted in
-the `Prepare WDT reset` state in Fig 1.  Hence, depending on the
-integrity class of the non-volatile store, this counter can be used as
-the snmpEngineBoots (RFC 2574) value, and the `sysinfo()` uptime value
-can be used as the snmpEngineTime.
+the `Prepare WDT reset` state in Fig 1.  This counter is cleared on
+power failure.
 
 The status can be read either from the file (status²), or by using the
 client API, like `watchdogctl` which returns (status¹).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -5,15 +5,19 @@ At runtime `watchdogd` runs as a regular priority task, periodically it
 sends a `WDIOC_KEEPALIVE` command to the driver.  As soon as it misses
 its deadline the underlying WDT will enforce a system reset.
 
+The `.state` file is saved across reboots and the `.status` file is a
+volatile file used to track if `watchdogd` has been started once before
+during this boot.
+
 ```
 (state)  /var/lib/watchdogd.state  |
 (status) /run/watchdogd.status     V
 ,,,,,                           .status
 [WDT]    WatchDog Timer         exists? ----------. yes, read
 `````                              |              | (status)
-                                   |      ,,,,,   |
-                                 What? <--[WDT]   |
-                                   |      `````   |
+                                   |       ,,,,,  |
+                                 Cause? <--[WDT]  |
+                                   |       `````  |
                                    |              |
           .---------- (status)<-- Who? <--(state) |
           |                        |         ^    |
@@ -37,13 +41,13 @@ its deadline the underlying WDT will enforce a system reset.
 When `watchdogd` starts it queries the WDT for the reset cause flags and
 then proceeds to read the (state) file from non-volatile store.  This
 was created before reset by `watchdogd` and contains more detailed info
-on the cause of the reset, see Fi. 2 below for an overview.  The data
-collected is the stored in a (status) file, which can be volatile store.
-Should the daemon be restarted at runtime, for whatever reason, it can
-quickly pick up where it left of by checking for the existence of this
-(status) file.  Before entering the main loop, the daemon sets the WDT
-timeout and opens a client socket.  In the main loop the daemon kicks
-the WDT periodically and responds to client requests.
+on reset reason, see Fig. 2 below for an overview.  The data collected
+is the stored in a (status) file, which can be volatile store.  Should
+the daemon be restarted at runtime, for whatever reason, it can quickly
+pick up where it left of by checking for the existence of this (status)
+file.  Before entering the main loop, the daemon sets the WDT timeout
+and opens a client socket.  In the main loop the daemon kicks the WDT
+periodically and responds to client requests.
 
 For each reboot `watchdogd` maintains a reset counter, along with the
 data collected in the (state) file.  This reset counter is incremeted in
@@ -70,9 +74,9 @@ can query this information when needed.
 
 When the system starts up (1) `watchdogd` first tries to ascertain why
 the system is starting up.  The below sequence diagram is used and each
-of the states below are possible end states, including (WDT).  In fact
-the (WDT) state is the default cause stored by `watchdogd` in the log in
-case of CPU overload.
+of the states below are possible end states, including WDT.  The WDT is
+the default reason stored by `watchdogd` in the log in case of CPU
+overload.
 
 ```
         (1)
@@ -83,18 +87,26 @@ case of CPU overload.
          |           |
      (PID Fail)   (Reboot)
 
-Fig. 2: Reset cause FTA
+Fig. 2: Reset reason FTA
 ```
 
 
 Recommendations
 ---------------
 
-Primarily you need to be able to distinguish between a power failure
-(PWR Fail) and a WDT timeout.  The latter can be caused by one of two
-things: a process misses its deadline or a user issuing reboot.  The
-former of these two can be a monitored process or watchdogd itself
-failing to kick the WDT driver.
+The system WDT driver must be able to distinguish between a power
+failure (`WDIOF_POWERUNDER`) and WDT timeout (`WDIOF_CARDRESET`).
+The latter can be caused by one of three things:
+
+  1. a monitored process misses its deadline,
+  2. a user issuing reboot, or
+  3. a system overload
+  
+A monitored process, PID Fail in Figure 2, or a user issuing `reboot` is
+handled by `watchdogd`.  Both are logged with a unique reset reason code
+in the log file.  If watchdogd itself fails to kick the WDT driver it is
+logged as "unknown", since the real reason is unknown, but likely to be
+a system overload situation.
 
 On systems where you cannot distinguish between a power failure and a
 WDT timeout it is impossible to provide adequate information to an NMS.
@@ -104,7 +116,7 @@ particular, always make sure to connect the RESETn signal of the WDT to
 all relevant circuitry to ensure a WDT reset set the HW in the same
 state as after a regular PWR ON.
 
-In kernel driver terms, lokk for a chipset + driver supporting these
+In kernel driver terms, look for a chipset + driver supporting these
 flags: `WDIOF_SETTIMEOUT | WDIOF_POWERUNDER | WDIOF_CARDRESET |
 WDIOF_KEEPALIVEPING`
 

--- a/examples/ex2.c
+++ b/examples/ex2.c
@@ -45,9 +45,18 @@ int main(int argc, char *argv[])
 	DEBUG("OK (debug:%d)!", id);
 
 	wdog_reset_reason(&reason);
-	printf("Reset reason: %s\n", wdog_reset_reason_str(&reason));
-	printf("wid %d, label %s, cause: %d, counter: %u\n",
-	       reason.wid, reason.label, reason.cause, reason.counter);
+	printf("Reset counter: %u\n", reason.counter);
+	printf("Reset reason: %d - %s\n", reason.code, wdog_reset_reason_str(&reason));
+	switch (reason.code) {
+	case WDOG_FAILED_SUBSCRIPTION:
+	case WDOG_FAILED_KICK:
+	case WDOG_FAILED_UNSUBSCRIPTION:
+	case WDOG_FAILED_TO_MEET_DEADLINE:
+		printf("Process wid %d, label %s\n", reason.wid, reason.label);
+		break;
+	default:
+		break;
+	}
 
 	id = wdog_subscribe(NULL, 2000, &ack);
 	if (id < 0) {

--- a/man/watchdogctl.1
+++ b/man/watchdogctl.1
@@ -13,16 +13,16 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd Jan 3, 2018
-.Dt WATCHDOGCTL 1
-.Os "watchdogd (3.0)"
+.Dd Jan 10, 2020
+.Dt WATCHDOGCTL 1 SMM
+.Os
 .Sh NAME
 .Nm watchdogctl
 .Nd Status and control tool for watchdogd
 .Sh SYNOPSIS
 .Nm
 .Op Fl hvV
-.Op Fl c Ar CAUSE
+.Op Fl c Ar CODE
 .Op Fl p Ar PID
 .Op clear
 .Op disable | enable
@@ -39,8 +39,8 @@ provides a safe way of querying status and controlling
 .Xr watchdogd 8 .
 .Sh OPTIONS
 .Bl -tag -width Ds
-.It Fl c, -cause Ar CAUSE
-Reset cause for fail command.  Possible values:
+.It Fl c, -code Ar CODE
+Reset reason codes for fail command:
 .Pp
 .Bl -tag -width false-unsubscribe -compact -offset indent
 .It Cm 1
@@ -65,7 +65,7 @@ Memory leak
 CPU overload
 .El
 .Pp
-Causes can also be listed at runtime with:
+Codes can also be listed at runtime with:
 .Fl c Ar help
 .It Fl h, -help
 Show help message.
@@ -80,7 +80,7 @@ Show version information.
 Short forms of the below commands are allowed, as long as it is unique.
 .Bl -tag -width Ds
 .It Cm clear
-Clear reset cause.
+Clear reset reason.
 .It Cm counter
 Show reset counter, number of reboots since power-on.
 .It Cm debug
@@ -105,7 +105,8 @@ Alias to
 .Cm reset .
 .It Cm reset Oo MSEC Oc Oo MSG Oc
 Perform system reset, with an optional millisecond delay and an optional
-message to be stored as the reset cause label.  A zero
+message to be stored as the reset reason label (usually process name).
+A zero
 .Ar MSEC
 argument is the same as omitting the argument, leading to an immediate
 reset.  On systems with
@@ -116,8 +117,8 @@ unmount all file systems) before performing the WDT reset.
 .It Cm fail Oo MSEC Oc Oo MSG Oc
 Like the
 .Cm reset
-command, records reset cause (see above
-.Fl c CAUSE )
+command, records reset reason (see above
+.Fl c CODE )
 but does not reboot unless
 .Ar MSEC
 is given.  I.e., omitting the
@@ -126,7 +127,7 @@ argument does not have the same effect as in the
 .Cm reset
 command.
 .It Cm status
-Query status of daemon and show last reset cause, default command.
+Query status of daemon and show last reset reason, default command.
 .It Cm test Op TEST
 Run built-in tests of process supervisor functionality in daemon.  These
 tests can be disabled at build time, so they may not be available in the
@@ -163,7 +164,7 @@ Daemon configuration file. Read once when starting up and on SIGHUP or
 .Cm reload
 command.
 .It Pa /run/watchdogd.status
-Read to present WDT status and reset cause
+Read to present WDT status and reset reason
 .It Pa /run/watchdogd.sock
 Used to connect to
 .Nm watchdogd

--- a/man/watchdogd.8
+++ b/man/watchdogd.8
@@ -13,9 +13,9 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd Jan 3, 2018
-.Dt WATCHDOGD 8
-.Os "watchdogd (3.0)"
+.Dd Jan 10, 2020
+.Dt WATCHDOGD 8 SMM
+.Os
 .Sh NAME
 .Nm watchdogd
 .Nd Advanced system & process monitor daemon
@@ -32,13 +32,18 @@
 is an advanced system and process supervisor daemon, primarily intended
 for embedded Linux and server systems.  It can monitor critical system
 resources, supervise the heartbeat of processes and record deadline
-transgressions before safely rebooting your system.
+transgressions, and initiate a controlled reset if needed.
 .Pp
-When a system comes back up after a reset,
+When a system starts up,
 .Nm
-determines the reset cause and records it in a logfile for later
-analysis by an operator or network management system (NMS).  This
-information can in turn then be used to put the system in an operational
+determines the
+.Em reset cause
+by querying the kernel.  I case of system reset, and not power loss, the
+.Em reset reason
+is available already in a file, stored by
+.Nm
+before the reset.  This reset reason can be then be used by an operator
+or network management system (NMS) to put the system in an operational
 safe state, or non-operational safe state.
 .Sh WATCHDOG
 A watchdog timer (WDT) is something most motherboards of laptops and
@@ -54,8 +59,8 @@ which could be good enough.
 .Pp
 The idea is to have a watchdog daemon in userspace that runs in the
 background of your system.  When there is no more CPU time for the
-watchdog daemon to run it will fail to "kick" the WDT.  This will in
-turn cause the WDT to reboot the system.
+watchdog daemon to run, it fails to "kick" the kernel WDT driver, which
+in turn causes the WDT to reboot the system.
 .Sh OPTIONS
 Earlier versions of
 .Nm
@@ -130,19 +135,24 @@ command from
 State pre boot, lists coming (re)boot reason.  Do not rely on the
 contents of this file, it is used by
 .Nm
-to maintain state across boots.  If you want the status and reset cause,
-read
+to maintain state across boots.  If you want the status and reset
+reason, read
 .Pa /run/watchdogd.status
 instead.
 .It Pa /run/watchdogd.pid
 For convenience to other processes when sending signals.  Also a useful
 synchronization point, because the PID file is only created when
 .Nm
-is ready to receive signals and register processes with the process supervisor API
+is ready to receive signals and register processes with the process
+supervisor API
 .It Pa /run/watchdogd.status
-Current status, contains HW WDT status word,
+Current status, contains kernel WDT
+.Em reset cause ,
 .Nm
-timeout and period, and the reset cause information from this boot.
+timeout and period, and the
+.Em reset reason
+.Nm
+determined from this boot.
 .It Pa /run/watchdogd.sock
 UNIX domain socket used by libwdog and
 .Nm watchdogctl

--- a/man/watchdogd.conf.5
+++ b/man/watchdogd.conf.5
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd Jan 10, 2018
+.Dd Jan 10, 2020
 .Dt WATCHDOGD 5 SMM
 .Os
 .Sh NAME
@@ -72,10 +72,11 @@ script.sh {filenr, loadavg, meminfo} {crit, warn} VALUE
 .Ed
 .Pp
 Health monitor plugins also have their own local script setting.
-.It Cm reset-cause Ar {}
-This section controls the reset cause \& reset counter.  By default this
-is disabled, since not all systems allow writing to disk, e.g. embedded
-systems using MTD devices with limited number of write cycles.
+.It Cm reset-reason Ar {}
+This section controls the reset reason, including the reset counter.  By
+default this is disabled, since not all systems allow writing to disk,
+e.g. embedded systems using MTD devices with limited number of write
+cycles.
 .Pp
 Another backend can be implemented and linked to the daemon, but make
 sure to
@@ -89,6 +90,11 @@ The default file setting is a non-volatile path, according to the FHS.
 It can be changed to another location, but make sure that location is
 writable first.
 .El
+.Pp
+.Sy Note:
+This section was previously called
+.Cm reset-cause ,
+which is deprecated and may be removed in a future release.
 .El
 .Ss Process Supervisor
 .Bl -tag -width TERM
@@ -277,7 +283,7 @@ supervisor {
     priority = 98
 }
 
-reset-cause {
+reset-reason {
     enabled = false
 #    file    = "/var/lib/watchdogd.state"
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,5 +42,5 @@ pkgincludedir       = $(includedir)/wdog
 pkginclude_HEADERS  =           wdog.h  compat.h
 libwdog_la_SOURCES  = wdog.c	wdog.h  compat.h
 libwdog_la_CFLAGS   = $(lite_CFLAGS) $(AM_CFLAGS)
-libwdog_la_LDFLAGS  = -version-info 1:1:0
+libwdog_la_LDFLAGS  = -version-info 2:0:0
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,8 +22,8 @@ endif
 if GENERIC_PLUGIN
 watchdogd_SOURCES  += generic.c		generic.h
 endif
-if RCFILE
-watchdogd_SOURCES  += rcfile.c		rc.h
+if RRFILE
+watchdogd_SOURCES  += rrfile.c		rr.h
 endif
 
 watchdogd_CPPFLAGS  = -D_GNU_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_XOPEN_SOURCE

--- a/src/api.c
+++ b/src/api.c
@@ -98,9 +98,9 @@ static void cmd(uev_t *w, void *arg, int events)
 	case WDOG_KICK_CMD:
 	case WDOG_RESET_CMD:
 	case WDOG_RESET_COUNTER_CMD:
-	case WDOG_RESET_CAUSE_CMD:
-	case WDOG_RESET_CAUSE_RAW_CMD:
-	case WDOG_CLEAR_CAUSE_CMD:
+	case WDOG_RESET_REASON_CMD:
+	case WDOG_RESET_REASON_RAW_CMD:
+	case WDOG_CLEAR_REASON_CMD:
 	case WDOG_FAILED_SYSTEMOK_CMD...WDOG_FAILED_OVERLOAD_CMD:
 		if (supervisor_cmd(w->ctx, &req)) {
 			req.cmd = WDOG_CMD_ERROR;

--- a/src/conf.c
+++ b/src/conf.c
@@ -20,7 +20,7 @@
 #include <sched.h>
 
 #include "wdt.h"
-#include "rc.h"
+#include "rr.h"
 #include "script.h"
 #include "filenr.h"
 #include "loadavg.h"

--- a/src/conf.c
+++ b/src/conf.c
@@ -81,12 +81,12 @@ static int generic_plugin_checker(uev_ctx_t *ctx, cfg_t *cfg)
 }
 #endif
 
-static int reset_cause(uev_ctx_t *ctx, cfg_t *cfg)
+static int validate_reset_reason(uev_ctx_t *ctx, cfg_t *cfg)
 {
 	if (!cfg)
-		return reset_cause_init(0, NULL);
+		return reset_reason_init(0, NULL);
 
-	return reset_cause_init(cfg_getbool(cfg, "enabled"), cfg_getstr(cfg, "file"));
+	return reset_reason_init(cfg_getbool(cfg, "enabled"), cfg_getstr(cfg, "file"));
 }
 
 static int validate_file(cfg_t *cfg, cfg_opt_t *opt)
@@ -106,12 +106,12 @@ static int validate_file(cfg_t *cfg, cfg_opt_t *opt)
 
 	dir = dirname(tmp);
 	if (file[0] != '/' || !dir) {
-		cfg_error(cfg, "reset-cause file must be an absolute path, skipping.");
+		cfg_error(cfg, "reset-reason backend file must be an absolute path, skipping.");
 		goto done;
 	}
 
 	if (access(dir, R_OK | W_OK)) {
-		cfg_error(cfg, "reset-cause dir '%s' not writable, error %d:%s.", dir, errno, strerror(errno));
+		cfg_error(cfg, "reset-reason dir '%s' not writable, error %d:%s.", dir, errno, strerror(errno));
 		goto done;
 	}
 
@@ -178,7 +178,7 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 		CFG_STR ("script",   NULL, CFGF_NONE),
 		CFG_END()
 	};
-	cfg_opt_t reset_cause_opts[] =  {
+	cfg_opt_t reset_reason_opts[] =  {
 		CFG_BOOL("enabled",  cfg_false, CFGF_NONE),
 		CFG_STR ("file",     NULL, CFGF_NONE),
 		CFG_END()
@@ -206,7 +206,8 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 		CFG_INT ("timeout",     WDT_TIMEOUT_DEFAULT, CFGF_NONE),
 		CFG_BOOL("safe-exit",   cfg_false, CFGF_NONE),
 		CFG_SEC ("supervisor",  supervisor_opts, CFGF_NONE),
-		CFG_SEC ("reset-cause", reset_cause_opts, CFGF_NONE),
+		CFG_SEC ("reset-cause", reset_reason_opts, CFGF_NONE), /* Compat only */
+		CFG_SEC ("reset-reason", reset_reason_opts, CFGF_NONE),
 		CFG_STR ("script",      NULL, CFGF_NONE),
 		CFG_SEC ("filenr",      checker_opts, CFGF_NONE),
 		CFG_SEC ("loadavg",     checker_opts, CFGF_NONE),
@@ -214,7 +215,7 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 		CFG_SEC ("generic",     generic_plugin_opts, CFGF_NONE),
 		CFG_END()
 	};
-	cfg_t *cfg;
+	cfg_t *cfg, *opt;
 
 	if (!ctx) {
 		ERROR("Internal error, no event context");
@@ -240,7 +241,8 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 
 	/* Validators */
 	cfg_set_validate_func(cfg, "supervisor|priority", validate_priority);
-	cfg_set_validate_func(cfg, "reset-cause|file", validate_file);
+	cfg_set_validate_func(cfg, "reset-cause|file", validate_file); /* Compat only */
+	cfg_set_validate_func(cfg, "reset-reason|file", validate_file);
 
 	switch (cfg_parse(cfg, file)) {
 	case CFG_FILE_ERROR:
@@ -265,7 +267,10 @@ int conf_parse_file(uev_ctx_t *ctx, char *file)
 
 	script_init(ctx, cfg_getstr(cfg, "script"));
 	supervisor(ctx, cfg_getnsec(cfg, "supervisor", 0));
-	reset_cause(ctx, cfg_getnsec(cfg, "reset-cause", 0));
+	opt = cfg_getnsec(cfg, "reset-reason", 0);
+	if (!opt)
+		opt = cfg_getnsec(cfg, "reset-cause", 0); /* Compat only */
+	validate_reset_reason(ctx, opt);
 
 #ifdef FILENR_PLUGIN
 	checker(ctx, cfg, "filenr", filenr_init);

--- a/src/private.h
+++ b/src/private.h
@@ -43,9 +43,9 @@
 #define WDOG_ENABLE_CMD             10
 #define WDOG_STATUS_CMD             11
 #define WDOG_RESET_CMD              12
-#define WDOG_RESET_CAUSE_CMD        13
-#define WDOG_RESET_CAUSE_RAW_CMD    14
-#define WDOG_CLEAR_CAUSE_CMD        15
+#define WDOG_RESET_REASON_CMD       13
+#define WDOG_RESET_REASON_RAW_CMD   14
+#define WDOG_CLEAR_REASON_CMD       15
 #define WDOG_SET_LOGLEVEL_CMD       16
 #define WDOG_GET_LOGLEVEL_CMD       17
 #define WDOG_RESET_COUNTER_CMD      18

--- a/src/rc.h
+++ b/src/rc.h
@@ -1,4 +1,4 @@
-/* Reset cause API for backend store
+/* Reset reason API for backend store
  *
  * Copyright (C) 2017  Joachim Nilsson <troglobit@gmail.com>
  *
@@ -18,10 +18,10 @@
 #ifndef RC_H_
 #define RC_H_
 
-extern int reset_cause_init  (int enabled, char *file);
-extern int reset_cause_set   (wdog_reason_t *reason, pid_t  pid);
-extern int reset_cause_get   (wdog_reason_t *reason, pid_t *pid);
-extern int reset_cause_clear (wdog_reason_t *reason);
+extern int reset_reason_init  (int enabled, char *file);
+extern int reset_reason_set   (wdog_reason_t *reason, pid_t  pid);
+extern int reset_reason_get   (wdog_reason_t *reason, pid_t *pid);
+extern int reset_reason_clear (wdog_reason_t *reason);
 
 #endif /* RC_H_ */
 

--- a/src/rcfile.c
+++ b/src/rcfile.c
@@ -1,4 +1,4 @@
-/* Watchdog API for reset cause, file store backend
+/* Watchdog API for reset reason, file store backend
  *
  * Copyright (C) 2012-2017  Joachim Nilsson <troglobit@gmail.com>
  *
@@ -22,7 +22,7 @@ static int rcenabled = 0;
 static char *rcfile  = NULL;
 
 
-int reset_cause_init(int enabled, char *file)
+int reset_reason_init(int enabled, char *file)
 {
 	if (rcfile)
 		free(rcfile);
@@ -36,7 +36,7 @@ int reset_cause_init(int enabled, char *file)
 	return 0;
 }
 
-int reset_cause_set(wdog_reason_t *reason, pid_t pid)
+int reset_reason_set(wdog_reason_t *reason, pid_t pid)
 {
 	FILE *fp;
 	const char *state;
@@ -64,7 +64,7 @@ int reset_cause_set(wdog_reason_t *reason, pid_t pid)
 	return 0;
 }
 
-int reset_cause_get(wdog_reason_t *reason, pid_t *pid)
+int reset_reason_get(wdog_reason_t *reason, pid_t *pid)
 {
 	FILE *fp;
 	const char *state;
@@ -105,7 +105,7 @@ int reset_cause_get(wdog_reason_t *reason, pid_t *pid)
  * the reset counter.  E.g. to detect sudden power-loss.  So this
  * function is then called with all fields cleared but counter.
  */
-int reset_cause_clear(wdog_reason_t *r)
+int reset_reason_clear(wdog_reason_t *r)
 {
 	wdog_reason_t reason;
 
@@ -113,7 +113,7 @@ int reset_cause_clear(wdog_reason_t *r)
 	if (!r)
 		r = &reason;
 
-	return reset_cause_set(r, 0);
+	return reset_reason_set(r, 0);
 }
 
 /**

--- a/src/rr.h
+++ b/src/rr.h
@@ -15,15 +15,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef RC_H_
-#define RC_H_
+#ifndef RR_H_
+#define RR_H_
 
 extern int reset_reason_init  (int enabled, char *file);
 extern int reset_reason_set   (wdog_reason_t *reason, pid_t  pid);
 extern int reset_reason_get   (wdog_reason_t *reason, pid_t *pid);
 extern int reset_reason_clear (wdog_reason_t *reason);
 
-#endif /* RC_H_ */
+#endif /* RR_H_ */
 
 /**
  * Local Variables:

--- a/src/rrfile.c
+++ b/src/rrfile.c
@@ -18,20 +18,20 @@
 #include "wdt.h"
 #include <stdio.h>
 
-static int rcenabled = 0;
-static char *rcfile  = NULL;
+static int rrenabled = 0;
+static char *rrfile  = NULL;
 
 
 int reset_reason_init(int enabled, char *file)
 {
-	if (rcfile)
-		free(rcfile);
+	if (rrfile)
+		free(rrfile);
 
 	if (!file)
-		rcfile = strdup(WDOG_STATE);
+		rrfile = strdup(WDOG_STATE);
 	else
-		rcfile = strdup(file);
-	rcenabled = enabled;
+		rrfile = strdup(file);
+	rrenabled = enabled;
 
 	return 0;
 }
@@ -44,9 +44,9 @@ int reset_reason_set(wdog_reason_t *reason, pid_t pid)
 	if (wdt_testmode())
 		state = WDOG_STATE_TEST;
 	else
-		state = rcfile;
+		state = rrfile;
 
-	if (!rcenabled || !rcfile) {
+	if (!rrenabled || !rrfile) {
 		DEBUG("Reset cause back-end disabled.");
 		return 0;
 	}
@@ -75,12 +75,12 @@ int reset_reason_get(wdog_reason_t *reason, pid_t *pid)
 	if (wdt_testmode())
 		state = WDOG_STATE_TEST;
 	else
-		state = rcfile;
+		state = rrfile;
 
 	/* Clear contents to handle first boot */
 	memset(reason, 0, sizeof(*reason));
 
-	if (!rcenabled || !rcfile) {
+	if (!rrenabled || !rrfile) {
 		DEBUG("Reset cause back-end disabled.");
 		return 0;
 	}

--- a/src/supervisor.c
+++ b/src/supervisor.c
@@ -18,7 +18,7 @@
 #include <sched.h>
 #include "wdt.h"
 #include "private.h"
-#include "rc.h"
+#include "rr.h"
 #include "wdog.h"
 #include "script.h"
 #include "supervisor.h"

--- a/src/wdog.c
+++ b/src/wdog.c
@@ -167,8 +167,8 @@ static int doit(int cmd, int id, char *label, unsigned int timeout, unsigned int
 		goto error;
 	}
 
-	if (cmd == WDOG_RESET_CAUSE_CMD ||
-	    cmd == WDOG_RESET_CAUSE_RAW_CMD)
+	if (cmd == WDOG_RESET_REASON_CMD ||
+	    cmd == WDOG_RESET_REASON_RAW_CMD)
 		memcpy(ack, &req, sizeof(wdog_reason_t));
 	else if (ack)
 		*ack = req.next_ack;
@@ -275,9 +275,9 @@ int wdog_status(int *status)
 	return doit(WDOG_STATUS_CMD, 0, NULL, 0, (unsigned int *)status);
 }
 
-int wdog_failed(wdog_cause_t cause, int pid, char *label, unsigned int timeout)
+int wdog_failed(wdog_code_t code, int pid, char *label, unsigned int timeout)
 {
-	return doit(cause + WDOG_FAILED_BASE_CMD, pid, label, timeout, NULL);
+	return doit(code + WDOG_FAILED_BASE_CMD, pid, label, timeout, NULL);
 }
 
 int wdog_reset(pid_t pid, char *label)
@@ -294,7 +294,7 @@ int wdog_reset(pid_t pid, char *label)
  * file systems etc.
  *
  * This function is what init can use to order watchdogd to save the
- * reset cause before initiating the shutdown.  When this function has
+ * reset reason before initiating the shutdown.  When this function has
  * been called, with a reasonable timeout, watchdogd will go into a
  * special mode waiting only for SIGTERM.
  *
@@ -325,7 +325,7 @@ int wdog_reset_reason(wdog_reason_t *reason)
 		return -1;
 	}
 
-	return doit(WDOG_RESET_CAUSE_CMD, 0, NULL, 0, (unsigned int *)reason);
+	return doit(WDOG_RESET_REASON_CMD, 0, NULL, 0, (unsigned int *)reason);
 }
 
 int wdog_reset_reason_raw(wdog_reason_t *reason)
@@ -335,7 +335,7 @@ int wdog_reset_reason_raw(wdog_reason_t *reason)
 		return -1;
 	}
 
-	return doit(WDOG_RESET_CAUSE_RAW_CMD, 0, NULL, 0, (unsigned int *)reason);
+	return doit(WDOG_RESET_REASON_RAW_CMD, 0, NULL, 0, (unsigned int *)reason);
 }
 
 char *wdog_reset_reason_str(wdog_reason_t *reason)
@@ -345,7 +345,7 @@ char *wdog_reset_reason_str(wdog_reason_t *reason)
 		return "Unknown";
 	}
 
-	switch (reason->cause) {
+	switch (reason->code) {
 	case WDOG_SYSTEM_NONE:
 		return "None";
 
@@ -386,7 +386,7 @@ char *wdog_reset_reason_str(wdog_reason_t *reason)
 
 int wdog_reset_reason_clr(void)
 {
-	return doit(WDOG_CLEAR_CAUSE_CMD, -1, NULL, 0, NULL);
+	return doit(WDOG_RESET_REASON_CMD, -1, NULL, 0, NULL);
 }
 
 int wdog_reload(void)

--- a/src/wdog.h
+++ b/src/wdog.h
@@ -25,26 +25,26 @@ extern "C"
 
 #include <time.h>
 
-/* Reset cause codes */
+/* Reset reason codes */
 typedef enum {
-	WDOG_SYSTEM_NONE = 0,    /* After reset/power-on */
-	WDOG_SYSTEM_OK,
-	WDOG_FAILED_SUBSCRIPTION,
-	WDOG_FAILED_KICK,
-	WDOG_FAILED_UNSUBSCRIPTION,
-	WDOG_FAILED_TO_MEET_DEADLINE,
-	WDOG_FORCED_RESET,
-	WDOG_FAILED_UNKNOWN,
-	WDOG_DESCRIPTOR_LEAK,
-	WDOG_MEMORY_LEAK,
-	WDOG_CPU_OVERLOAD,
-} wdog_cause_t;
+	WDOG_SYSTEM_NONE = 0,	      /* After reset/power-on */
+	WDOG_SYSTEM_OK,		      /* Unused? */
+	WDOG_FAILED_SUBSCRIPTION,     /* Supervised process */
+	WDOG_FAILED_KICK,	      /* Supervised process */
+	WDOG_FAILED_UNSUBSCRIPTION,   /* Supervised process */
+	WDOG_FAILED_TO_MEET_DEADLINE, /* Supervised process */
+	WDOG_FORCED_RESET,	      /* Operator requested system reboot */
+	WDOG_FAILED_UNKNOWN,	      /* Likely, WDT timed out*/
+	WDOG_DESCRIPTOR_LEAK,	      /* filenr  pluing */
+	WDOG_MEMORY_LEAK,	      /* meminfo plugin */
+	WDOG_CPU_OVERLOAD,	      /* loadavg plugin */
+} wdog_code_t;
 
 typedef struct
 {
-	unsigned int  counter;   /* Global reset counter since power-on, not per-cause */
+	unsigned int  counter;   /* Global reset counter, not per-reason */
 	unsigned int  wid;       /* Watchdog ID of process causing reset */
-	wdog_cause_t  cause;     /* Reset cause */
+	wdog_code_t   code;      /* Reset reason code, use wdog_reset_reason_str() */
 	unsigned int  enabled;   /* Unused, kept for compat. */
 	char          label[48]; /* Process name causing reset, or label */
 	struct tm     date;      /* Recorded time of reset */
@@ -59,7 +59,7 @@ char *wdog_get_loglevel     (void);
 int   wdog_enable           (int enable);   /* Attempt to temp. disable */
 int   wdog_status           (int *status);  /* Check if enabled */
 
-int   wdog_failed           (wdog_cause_t cause, int pid, char *label, unsigned int timeout);
+int   wdog_failed           (wdog_code_t code, int pid, char *label, unsigned int timeout);
 
 int   wdog_reset            (int pid, char *label);
 int   wdog_reset_timeout    (int pid, char *label, unsigned int timeout);

--- a/src/wdt.c
+++ b/src/wdt.c
@@ -254,13 +254,13 @@ int wdt_fload_reason(FILE *fp, wdog_reason_t *r, pid_t *pid)
 			continue;
 
 		if (string_match(buf, WDT_REASON_LBL ": ")) {
-			ptr += strlen(WDT_REASON_LBL) + 2;
+			ptr += sizeof(WDT_REASON_LBL) + 2;
 			strlcpy(r->label, chomp(ptr), sizeof(r->label));
 			continue;
 		}
 
 		if (string_match(buf, WDT_RESET_DATE ": ")) {
-			ptr += strlen(WDT_RESET_DATE) + 2;
+			ptr += sizeof(WDT_RESET_DATE) + 2;
 			strptime(chomp(ptr), "%FT%TZ", &r->date);
 			continue;
 		}

--- a/src/wdt.c
+++ b/src/wdt.c
@@ -408,13 +408,12 @@ int wdt_set_bootstatus(int timeout, int interval)
 	}
 
 	/*
-	 * Clear latest reset cause log IF and only IF WDT reports power
-	 * failure as cause of this boot.  Keep reset counter, that must
-	 * be reset using the API, snmpEngineBoots (RFC 2574)
+	 * Clear latest reset cause and counter IF and only IF the WDT
+	 * reports power failure as cause of this boot.
 	 */
 	if (cause & WDIOF_POWERUNDER) {
 		memset(&reason, 0, sizeof(reason));
-		reason.counter = reset_counter;
+		reset_counter = 0;
 		pid = 0;
 	}
 

--- a/src/wdt.c
+++ b/src/wdt.c
@@ -18,7 +18,7 @@
  */
 
 #include "wdt.h"
-#include "rc.h"
+#include "rr.h"
 #include "supervisor.h"
 
 static int fd = -1;

--- a/src/wdt.c
+++ b/src/wdt.c
@@ -369,8 +369,7 @@ static int create_bootstatus(char *fn, wdog_reason_t *r, int cause, int timeout,
 
 	fprintf(fp, WDT_TMOSEC_OPT ": %d\n", timeout);
 	fprintf(fp, WDT_INTSEC_OPT ": %d\n", interval);
-	fprintf(fp, WDT_BOOTSTATUS ": 0x%04x\n", cause >= 0 ? cause : 0);
-	fprintf(fp, WDT_RESETCAUSE ": %s\n", bootstatus_string(cause));
+	fprintf(fp, WDT_RESETCAUSE ": 0x%04x - %s\n", cause >= 0 ? cause : 0, bootstatus_string(cause));
 
 	 return wdt_fstore_reason(fp, r, pid);
 }

--- a/src/wdt.h
+++ b/src/wdt.h
@@ -52,10 +52,9 @@
 #define WDT_REASON_WID "Watchdog ID         "
 #define WDT_REASON_LBL "Label               "
 #define WDT_RESET_DATE "Reset date          "
-#define WDT_RESETCAUSE "Reset cause         "
+#define WDT_RESETCAUSE "Reset cause (WDIOF) "
 #define WDT_REASON_STR "Reset reason        "
 #define WDT_RESETCOUNT "Reset counter       "
-#define WDT_BOOTSTATUS "Boot status (WDIOF) "
 #define WDT_TMOSEC_OPT "Timeout (sec)       "
 #define WDT_INTSEC_OPT "Kick interval       "
 

--- a/src/wdt.h
+++ b/src/wdt.h
@@ -51,13 +51,13 @@
 #define WDT_REASON_PID "PID                 "
 #define WDT_REASON_WID "Watchdog ID         "
 #define WDT_REASON_LBL "Label               "
-#define WDT_REASON_TME "Reset date          "
-#define WDT_REASON_CSE "Reset cause         "
+#define WDT_RESET_DATE "Reset date          "
+#define WDT_RESETCAUSE "Reset cause         "
 #define WDT_REASON_STR "Reset reason        "
-#define WDT_REASON_CNT "Reset counter       "
-#define WDT_REASON_WDT "Boot status (WDIOF) "
-#define WDT_REASON_TMO "Timeout (sec)       "
-#define WDT_REASON_INT "Kick interval       "
+#define WDT_RESETCOUNT "Reset counter       "
+#define WDT_BOOTSTATUS "Boot status (WDIOF) "
+#define WDT_TMOSEC_OPT "Timeout (sec)       "
+#define WDT_INTSEC_OPT "Kick interval       "
 
 #define EMERG(fmt, args...)  syslog(LOG_EMERG,   fmt, ##args)
 #define ERROR(fmt, args...)  syslog(LOG_ERR,     fmt, ##args)
@@ -112,9 +112,8 @@ int wdt_forced_reset   (uev_ctx_t *ctx, pid_t pid, char *label, int timeout);
 int wdt_fload_reason   (FILE *fp, wdog_reason_t *r, pid_t *pid);
 int wdt_fstore_reason  (FILE *fp, wdog_reason_t *r, pid_t  pid);
 
-int wdt_set_bootstatus (int cause, int timeout, int interval);
+int wdt_set_bootstatus (int timeout, int interval);
 int wdt_get_bootstatus (void);
-
 
 static inline unsigned int wdt_reset_counter(void)
 {

--- a/watchdogd.conf
+++ b/watchdogd.conf
@@ -32,11 +32,13 @@
 # runs as a regular SCHED_OTHER process, this is the default.
 #
 # When a supervised process fails to meet its deadline, the daemon will
-# perform an unconditional reset having saved the reset cause.  If a
+# perform an unconditional reset having saved the reset reason.  If a
 # script is provided in this section it will be called instead.  The
 # script is called as:
 #
-#    script.sh supervisor CAUSE PID LABEL
+#    script.sh supervisor CODE PID LABEL
+#
+# Availabel CODEs for the reset reason are avilable in wdog.h
 #
 #supervisor {
 #    enabled  = false
@@ -44,8 +46,8 @@
 #    script = "/path/to/supervisor-script.sh"
 #}
 
-### Reset cause
-# The following section controls if/how the reset cause & reset counter
+### Reset reason
+# The following section controls if/how the reset reason & reset counter
 # is tracked.  By default this is disabled, since not all systems allow
 # writing to disk, e.g. embedded systems using MTD devices with limited
 # number of write cycles.  Another backend can be implemented and linked
@@ -54,7 +56,7 @@
 # The default file setting is a non-volatile path, according to the FHS.
 # It can be changed to another location, but make sure that location is
 # writable first.
-#reset-cause {
+#reset-reason {
 #    enabled = false
 #    file    = "/var/lib/watchdogd.state"
 #}


### PR DESCRIPTION
This patch set attempts to clarify the confusion in nomenclature used in watchdogd.  The changes are quite invasive, but the end result is a first step in lowering the barrier of entry and ease understanding for end-users.
