### PR TITLE
Sync socket protocol with current Finit

### DIFF
--- a/src/finit.c
+++ b/src/finit.c
@@ -43,7 +43,7 @@ int wdt_register(void)
 		return 0;
 	}
 
-	sd = socket(AF_UNIX, SOCK_STREAM, 0);
+	sd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
 	if (-1 == sd)
 		return -1;
 


### PR DESCRIPTION
Since commit [1845b7b](https://github.com/troglobit/finit/commit/1845b7b) Finit uses `SOCK_SEQPACKET` rather than `SOCK_STREAM`.