### PR TITLE
Fix crash in case the "Label" or "Reset date" field is empty

### DIFF
--- a/src/wdt.c
+++ b/src/wdt.c
@@ -258,8 +258,10 @@ int wdt_fload_reason(FILE *fp, wdog_reason_t *r, pid_t *pid)
 		if (string_match(buf, WDT_REASON_LBL)) {
 			ptr = strchr(buf, ':');
 			if (ptr) {
-				ptr += 2;
-				strlcpy(r->label, chomp(ptr), sizeof(r->label));
+				if (strlen(ptr) > 2) {
+					ptr += 2;
+					strlcpy(r->label, ptr, sizeof(r->label));
+				}
 			}
 			continue;
 		}
@@ -267,8 +269,10 @@ int wdt_fload_reason(FILE *fp, wdog_reason_t *r, pid_t *pid)
 		if (string_match(buf, WDT_RESET_DATE)) {
 			ptr = strchr(buf, ':');
 			if (ptr) {
-				ptr += 2;
-				strptime(chomp(ptr), "%FT%TZ", &r->date);
+				if (strlen(ptr) > 2) {
+					ptr += 2;
+					strptime(ptr, "%FT%TZ", &r->date);
+				}
 			}
 			continue;
 		}


### PR DESCRIPTION
chomp() on a empty string (strlen < 1) returns a NULL-ptr, which is not checked in strlcpy and leads to a crash.
The chomp here is not needed, because buf was chomped already before.
The string length check was added to make the following pointer operation safe (e.g. someone edits the file and deletes the space after the ':').