### PR TITLE
Address watchdogd service problem with generic script > 1s runtime #39

### DIFF
--- a/src/generic.c
+++ b/src/generic.c
@@ -65,7 +65,7 @@ static void generic_cb(uev_t *w, void *arg, int events)
 	}
 
 	gs->script_runtime += 1000;
-	if (gs->script_runtime >= gs->script_runtime_max) {
+	if (gs->script_runtime >= (gs->script_runtime_max * 1000)) {
 		ERROR("Monitor script PID %d still running after %d sec", gs->pid, gs->script_runtime_max);
 		if (checker_exec(gs->exec, "generic", 1, 255, gs->warning, gs->critical))
 			wdt_forced_reset(w->ctx, getpid(), PACKAGE ":generic", 0);


### PR DESCRIPTION
This commit addresses a problem related to the watchdogd service. When trying to
activate a generic monitoring script (in this example it's /usr/sbin/my-script.sh) with a runtime exceeding one second,
it triggers an unintended system reboot.

Our configuration is as follows:

generic {
enabled = true
interval = 60
timeout = 20
warning = 1
critical = 10
monitor-script = "/usr/sbin/my-script.sh"
}

The error message we're encountering reads as below (even though my-script returns 0):

```
sv-isup my-service
watchdogd[661]: Monitor script PID 1056 still running after 20 sec
exit 0
watchdog: watchdog0: watchdog did not stop!

```

Upon further investigation, it was determined that the problem arises
from the fact that 'gs->script_runtime' is measured in milliseconds,
while 'gs->script_runtime_max' is maintained in seconds, as indicated by the source code here: [link to source code](https://github.com/troglobit/watchdogd/blob/master/src/generic.c#L68). This commit rectifies the issue.

## Unit test results
With the fix in this PR there is no failure in watchdog service and it works as expected, please see below the traces.

```
sv-isup my-service
exit 0

```

