### PR TITLE
Fix typo/broken link in watchdogd.conf.5

### DIFF
--- a/man/watchdogd.conf.5
+++ b/man/watchdogd.conf.5
@@ -577,7 +577,7 @@ tempmon /sys/class/hwmon/hwmon1/temp1_input {
 .Ed
 .Sh SEE ALSO
 .Xr watchdogd 8
-.Xr watchdoctl 1
+.Xr watchdogctl 1
 .Sh AUTHORS
 .Nm
 is an improved version of the original, created by Michele d'Amico and


### PR DESCRIPTION
I just stumbled over the broken link in https://man.troglobit.com/man5/watchdogd.conf.5.html caused by this typo.